### PR TITLE
Add React eslint rule react/jsx-no-undef 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,8 @@
     "strict": [2, "never"],
     "react/jsx-uses-react": 2,
     "react/jsx-uses-vars": 2,
-    "react/react-in-jsx-scope": 2
+    "react/jsx-no-undef" : 2,
+    "react/react-in-jsx-scope": 2,
   },
   "plugins": [
     "react"


### PR DESCRIPTION
This rule is saving my life so often, i realized its not in the boilerplate. It gives an error when a component is not defined which can be really useful:

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-undef.md
