### PR TITLE
Add two eslint-related modules missing in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,14 @@
   "homepage": "http://mobxjs.github.com/mobx",
   "devDependencies": {
     "babel-core": "^6.9.1",
+    "babel-eslint": "^6.1.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-1": "^6.5.0",
     "eslint-plugin-react": "^5.1.1",
+    "eslint": "^2.13.1",
     "react-hot-loader": "^3.0.0-beta.2",
     "webpack": "^1.13.1",
     "webpack-dev-server": "^1.14.1"


### PR DESCRIPTION
Linting did not work if eslint was not installed globally. Since global npm packages are anti-pattern, it's better to list them all in `package.json`.
